### PR TITLE
Fix layout for RN > 0.28.0 and updated example

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "15.0.2",
-    "react-native": "^0.26.0",
+    "react": "^15.2.1",
+    "react-native": "^0.29.2",
     "react-native-photo-browser": "file:../"
   }
 }

--- a/lib/GridContainer.js
+++ b/lib/GridContainer.js
@@ -97,6 +97,7 @@ const styles = StyleSheet.create({
   },
   list: {
     justifyContent: 'flex-start',
+    alignItems: 'flex-start',
     flexDirection: 'row',
     flexWrap: 'wrap',
   },


### PR DESCRIPTION
Fix layout for RN > 0.28 and updated example. 
After upgrading to RN > 0.28 grid is showing only 3 images. Because changes in layout in  [RN 0.28 release](https://github.com/facebook/react-native/releases/tag/v0.28.0)