### PR TITLE
[#]修复 scroll初始化过程中 调用该方法 导致 layoutWidth==0 引起的 newIndex == NaX，导致程序出错

### DIFF
--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -179,7 +179,9 @@ export default class FullScreenContainer extends React.Component {
     const event = e.nativeEvent;
     const layoutWidth = event.layoutMeasurement.width;
     const newIndex = Math.floor((event.contentOffset.x + 0.5 * layoutWidth) / layoutWidth);
-
+    if(layoutWidth<= 0 ){
+      return;
+    }
     this._onPageSelected(newIndex);
   }
 


### PR DESCRIPTION
fix a bug: sometimes when scroll on init, _onScroll func was called and **layoutWidth was 0**,it cause an error and crash