### PR TITLE
fix: crash when scroll event's values are 0

### DIFF
--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -179,6 +179,8 @@ export default class FullScreenContainer extends React.Component {
     const event = e.nativeEvent;
     const layoutWidth = event.layoutMeasurement.width;
     const newIndex = Math.floor((event.contentOffset.x + 0.5 * layoutWidth) / layoutWidth);
+    
+    if (!isFinite(newIndex)) return;
 
     this._onPageSelected(newIndex);
   }


### PR DESCRIPTION
I don't know why, but the fact is `e.nativeEvent.layoutMeasurement.width` often be 0.

That results of `Infinity` when using `newIndex` and `currentMedia` will be `undefined`.

![image](https://cloud.githubusercontent.com/assets/2842176/24750732/85ee0520-1af9-11e7-8900-6e9b7f12c300.png)

Picture above is because of:

```javascript
console.log(newIndex, "!!!", event.layoutMeasurement); // add in `_onScroll(e)` function in FullScreenContainer.js

// output: Infinity "!!!" Object {width: 0, height: 0}
```