### PR TITLE
Add new property to control Status Bar: `displayStatusBar`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The component has both iOS and Android support.
 |**`alwaysShowControls`**|Boolean|Allows to control whether the bars and controls are always visible or whether they fade away to show the photo full.|`false`|
 |**`displayActionButton`**|Boolean|Show action button to allow sharing, copying, etc.|`false`|
 |**`displayNavArrows`**|Boolean|Whether to display left and right nav arrows on bottom toolbar.|`false`|
+|**`displayStatusBar`**|Boolean|Whether to display the OS Status Bar.|`true`|
 |**`displayTopBar`**|Boolean|Whether to display top bar.|`false`|
 |**`enableGrid`**|Boolean|Whether to allow the viewing of all the photo thumbnails on a grid.|`true`|
 |**`startOnGrid`**|Boolean|Whether to start on the grid of thumbnails instead of the first photo.|`false`|

--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -54,6 +54,7 @@ export default class FullScreenContainer extends React.Component {
     alwaysShowControls: PropTypes.bool,
     displayActionButton: PropTypes.bool,
     displayNavArrows: PropTypes.bool,
+    displayStatusBar: PropTypes.bool,
     displaySelectionButtons: PropTypes.bool,
     enableGrid: PropTypes.bool,
     useCircleProgress: PropTypes.bool,
@@ -66,6 +67,7 @@ export default class FullScreenContainer extends React.Component {
     initialIndex: 0,
     displayTopBar: true,
     displayNavArrows: false,
+    displayStatusBar: true,
     displaySelectionButtons: false,
     enableGrid: true,
     onGridButtonTap: () => {},
@@ -274,6 +276,7 @@ export default class FullScreenContainer extends React.Component {
   render() {
     const {
       displayNavArrows,
+      displayStatusBar,
       displayActionButton,
       onGridButtonTap,
       enableGrid,
@@ -284,7 +287,7 @@ export default class FullScreenContainer extends React.Component {
     return (
       <View style={styles.flex}>
         <StatusBar
-          hidden={!controlsDisplayed}
+          hidden={!displayStatusBar}
           showHideTransition={'slide'}
           barStyle={'light-content'}
           animated

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,11 @@ export default class PhotoBrowser extends React.Component {
     displayNavArrows: PropTypes.bool,
 
     /*
+     * Whether to display the OS Status Bar
+     */
+    displayStatusBar: PropTypes.bool,
+
+    /*
      * Whether to allow the viewing of all the photo thumbnails on a grid
      */
     enableGrid: PropTypes.bool,
@@ -104,6 +109,7 @@ export default class PhotoBrowser extends React.Component {
     alwaysShowControls: false,
     displayActionButton: false,
     displayNavArrows: false,
+    displayStatusBar: true,
     enableGrid: true,
     startOnGrid: false,
     displaySelectionButtons: false,
@@ -205,6 +211,7 @@ export default class PhotoBrowser extends React.Component {
     const {
       alwaysShowControls,
       displayNavArrows,
+      displayStatusBar,
       displaySelectionButtons,
       displayActionButton,
       enableGrid,
@@ -258,6 +265,7 @@ export default class PhotoBrowser extends React.Component {
           initialIndex={currentIndex}
           alwaysShowControls={alwaysShowControls}
           displayNavArrows={displayNavArrows}
+          displayStatusBar={displayStatusBar}
           displaySelectionButtons={displaySelectionButtons}
           displayActionButton={displayActionButton}
           enableGrid={enableGrid}


### PR DESCRIPTION
It will allow users of the component to have control of the state of the Status Bar independently of the state of the controls.
This should also address: https://github.com/halilb/react-native-photo-browser/issues/42

cc/ @fmelp and @Misioka