### PR TITLE
Added sqaure prop, so thumbnails can be square

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The component has both iOS and Android support.
 | Prop | Type | Description | Default |
 |---|---|---|---|
 |**`style`**|Style|Overrides default container style.|`null`|
+|**`square`**|Boolean|Displays the thumbnails as squares(same width, height).|`false`|
 |**`mediaList`**|Array\<Media\>|List of [media objects](#media-object) to display.|`[]`|
 |**`initialIndex`**|Number|Sets the visible photo initially.|`0`|
 |**`alwaysShowControls`**|Boolean|Allows to control whether the bars and controls are always visible or whether they fade away to show the photo full.|`false`|

--- a/lib/GridContainer.js
+++ b/lib/GridContainer.js
@@ -17,6 +17,7 @@ export default class GridContainer extends React.Component {
 
   static propTypes = {
     style: View.propTypes.style,
+    square: PropTypes.bool,
     dataSource: PropTypes.instanceOf(ListView.DataSource).isRequired,
     displaySelectionButtons: PropTypes.bool,
     onPhotoTap: PropTypes.func,
@@ -48,6 +49,7 @@ export default class GridContainer extends React.Component {
       onPhotoTap,
       onMediaSelection,
       itemPerRow,
+      square,
     } = this.props;
     const screenWidth = Dimensions.get('window').width;
     const photoWidth = (screenWidth / itemPerRow) - (ITEM_MARGIN * 2);
@@ -57,7 +59,7 @@ export default class GridContainer extends React.Component {
         <View style={styles.row}>
           <Photo
             width={photoWidth}
-            height={100}
+            height={square ? photoWidth : 100}
             resizeMode={'cover'}
             thumbnail
             progressImage={require('../Assets/hourglass.png')}

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,11 @@ export default class PhotoBrowser extends React.Component {
 
     mediaList: PropTypes.array.isRequired,
 
+    /**
+     * if thumbnails should have same height and width
+     */
+    square: PropTypes.bool,
+
     /*
      * set the current visible photo before displaying
      */
@@ -101,6 +106,7 @@ export default class PhotoBrowser extends React.Component {
   static defaultProps = {
     mediaList: [],
     initialIndex: 0,
+    square: false,
     alwaysShowControls: false,
     displayActionButton: false,
     displayNavArrows: false,
@@ -213,6 +219,7 @@ export default class PhotoBrowser extends React.Component {
       onBack,
       itemPerRow,
       style,
+      square,
     } = this.props;
     const {
       dataSource,
@@ -240,6 +247,7 @@ export default class PhotoBrowser extends React.Component {
             }}
           >
             <GridContainer
+              square={square}
               dataSource={dataSource}
               displaySelectionButtons={displaySelectionButtons}
               onPhotoTap={this._onGridPhotoTap}


### PR DESCRIPTION
Right now thumbnails are a fixed height of `100`, so they make look rectangular on some layouts. This PR adds a square prop, so that the thumbnails can have the same height as they do width.

Before and after:

<img width="653" alt="screen shot 2017-07-19 at 9 01 01 pm" src="https://user-images.githubusercontent.com/5962998/28395900-90b7b73a-6cc5-11e7-89ab-73d6d7670474.png">
<img width="656" alt="screen shot 2017-07-19 at 9 02 04 pm" src="https://user-images.githubusercontent.com/5962998/28395901-90d370ba-6cc5-11e7-818d-2a9a1f545480.png">
