### PR TITLE
Add gridOffset prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The component has both iOS and Android support.
 | Prop | Type | Description | Default |
 |---|---|---|---|
 |**`style`**|Style|Overrides default container style.|`null`|
+|**`gridOffset`**|Number|Offset the width of the grid from the screen width.|`0`|
 |**`mediaList`**|Array\<Media\>|List of [media objects](#media-object) to display.|`[]`|
 |**`initialIndex`**|Number|Sets the visible photo initially.|`0`|
 |**`alwaysShowControls`**|Boolean|Allows to control whether the bars and controls are always visible or whether they fade away to show the photo full.|`false`|

--- a/lib/GridContainer.js
+++ b/lib/GridContainer.js
@@ -26,6 +26,11 @@ export default class GridContainer extends React.Component {
      * refresh the list to apply selection change
      */
     onMediaSelection: PropTypes.func,
+
+    /**
+     * offsets the width of the grid
+     */
+    offset: PropTypes.number,
   };
 
   static defaultProps = {
@@ -48,8 +53,9 @@ export default class GridContainer extends React.Component {
       onPhotoTap,
       onMediaSelection,
       itemPerRow,
+      offset,
     } = this.props;
-    const screenWidth = Dimensions.get('window').width;
+    const screenWidth = Dimensions.get('window').width - offset;
     const photoWidth = (screenWidth / itemPerRow) - (ITEM_MARGIN * 2);
 
     return (

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,11 @@ export default class PhotoBrowser extends React.Component {
 
     mediaList: PropTypes.array.isRequired,
 
+    /**
+     * offsets the width of the grid
+     */
+    gridOffset: PropTypes.number,
+
     /*
      * set the current visible photo before displaying
      */
@@ -112,6 +117,7 @@ export default class PhotoBrowser extends React.Component {
     displayTopBar: true,
     onPhotoLongPress: () => {},
     delayPhotoLongPress: 1000,
+    gridOffset: 0,
   };
 
   constructor(props, context) {
@@ -213,6 +219,7 @@ export default class PhotoBrowser extends React.Component {
       onBack,
       itemPerRow,
       style,
+      gridOffset,
     } = this.props;
     const {
       dataSource,
@@ -240,6 +247,7 @@ export default class PhotoBrowser extends React.Component {
             }}
           >
             <GridContainer
+              offset={gridOffset}
               dataSource={dataSource}
               displaySelectionButtons={displaySelectionButtons}
               onPhotoTap={this._onGridPhotoTap}


### PR DESCRIPTION
Current the width of the thumbnails are calculated using the full width of the screen. However if there's a sidebar then the item width gets calculated incorrectly.

This PR adds the `gridOffset` prop so that the grid item width can be calculated correctly.

Before and after:

![screenshot_1500513420](https://user-images.githubusercontent.com/5962998/28396170-b4873ca6-6cc7-11e7-8107-5abe5e1b96d9.png)
![screenshot_1500513438](https://user-images.githubusercontent.com/5962998/28396171-b49df720-6cc7-11e7-8c1a-186ee1cc3f0a.png)
