### PR TITLE
Fix property names & default values in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The component has both iOS and Android support.
 |**`alwaysShowControls`**|Boolean|Allows to control whether the bars and controls are always visible or whether they fade away to show the photo full.|`false`|
 |**`displayActionButton`**|Boolean|Show action button to allow sharing, copying, etc.|`false`|
 |**`displayNavArrows`**|Boolean|Whether to display left and right nav arrows on bottom toolbar.|`false`|
-|**`displayStatusBar`**|Boolean|Whether to display the OS Status Bar.|`true`|
-|**`displayTopBar`**|Boolean|Whether to display top bar.|`false`|
+|**`alwaysDisplayStatusBar`**|Boolean|Whether to display the OS Status Bar.|`false`|
+|**`displayTopBar`**|Boolean|Whether to display top bar.|`true`|
 |**`enableGrid`**|Boolean|Whether to allow the viewing of all the photo thumbnails on a grid.|`true`|
 |**`startOnGrid`**|Boolean|Whether to start on the grid of thumbnails instead of the first photo.|`false`|
 |**`displaySelectionButtons`**|Boolean|Whether selection buttons are shown on each image.|`false`|


### PR DESCRIPTION
Fixes the following errors in prop. documentation:

- [`displayStatusBar` should be `alwaysDisplayStatusBar`](https://github.com/halilb/react-native-photo-browser/blob/2bca458e287febe34cf56fb8cfd7f9f89ee46897/lib/index.js#L60)
- [`alwaysDisplayStatusBar` has default value of `false`](https://github.com/halilb/react-native-photo-browser/blob/2bca458e287febe34cf56fb8cfd7f9f89ee46897/lib/index.js#L124)
- [`displayTopBar` has default value of `true`](https://github.com/halilb/react-native-photo-browser/blob/2bca458e287febe34cf56fb8cfd7f9f89ee46897/lib/index.js#L130)