### PR TITLE
Fixes grid cutoff

### DIFF
--- a/lib/GridContainer.js
+++ b/lib/GridContainer.js
@@ -105,7 +105,7 @@ export default class GridContainer extends React.Component {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingBottom: Constants.TOOLBAR_HEIGHT,
+    paddingBottom: Constants.TOOLBAR_HEIGHT + 70,
   },
   list: {
     justifyContent: 'flex-start',


### PR DESCRIPTION
Currently the images in the grid container at the bottom are cut off. It seems like a result of the paddingTop on the container. However if we set the `paddingTop: 0` in the using the `style` prop, then the full screen view crops off the top of the image.

This PR offsets the `paddingBottom` on the **`GridContainer`** so the images display fully as expected.

## Before
![screen shot 2017-07-30 at 2 34 33 pm](https://user-images.githubusercontent.com/5962998/28756056-66be3a80-7535-11e7-8acd-f783b767deb9.png)

## After
![screen shot 2017-07-30 at 2 34 13 pm](https://user-images.githubusercontent.com/5962998/28756057-6e43c5f4-7535-11e7-8ebb-aa27b606699d.png)