### PR TITLE
Navigator component has been deprecated

### DIFF
--- a/Example/PhotoBrowserExample.js
+++ b/Example/PhotoBrowserExample.js
@@ -9,12 +9,13 @@ import {
   CameraRoll,
   ListView,
   StyleSheet,
-  Navigator,
   Text,
   TouchableOpacity,
   View,
   Platform,
 } from 'react-native';
+
+import { Navigator } from 'react-native-deprecated-custom-components';
 
 import PhotoBrowser from 'react-native-photo-browser';
 

--- a/Example/package.json
+++ b/Example/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "react": "16.0.0-alpha.6",
     "react-native": "0.43.3",
+    "react-native-deprecated-custom-components": "^0.1.1",
     "react-native-photo-browser": "file:../"
   }
 }


### PR DESCRIPTION
It now needs to be imported from `react-native-deprecated-custom-components`