### PR TITLE
Support pinch to zoom on full-screen photos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The component has both iOS and Android support.
 |**`delayPhotoLongPress`**|Number|The long press delay in `ms`.|`1000`|
 |**`square`**|Boolean|Displays the thumbnails as squares(same width, height).|`false`|
 |**`gridOffset`**|Number|Offset the width of the grid from the screen width.|`0`|
+|**`enablePinchToZoom`**|Boolean|Whether or not to enable pinch to zoom when viewing full-screen photos.|`true`|
 
 ### Media Object
 

--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -62,7 +62,8 @@ export default class FullScreenContainer extends React.Component {
     useCircleProgress: PropTypes.bool,
     onActionButton: PropTypes.func,
     onPhotoLongPress: PropTypes.func,
-    delayLongPress: PropTypes.number
+    delayLongPress: PropTypes.number,
+    enablePinchToZoom: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -75,6 +76,7 @@ export default class FullScreenContainer extends React.Component {
     onGridButtonTap: () => {},
     onPhotoLongPress: () => {},
     delayLongPress: 1000,
+    enablePinchToZoom: true,
   };
 
   constructor(props, context) {
@@ -230,22 +232,21 @@ export default class FullScreenContainer extends React.Component {
 
     return (
       <View key={`row_${rowID}`} style={styles.flex}>
-        <TouchableWithoutFeedback
+        <Photo
+          ref={ref => this.photoRefs[rowID] = ref}
+          lazyLoad
+          useCircleProgress={useCircleProgress}
+          uri={media.photo}
+          displaySelectionButtons={displaySelectionButtons}
+          selected={media.selected}
+          enablePinchToZoom={this.props.enablePinchToZoom}
+          onSelection={(isSelected) => {
+            onMediaSelection(rowID, isSelected);
+          }}
           onPress={this._toggleControls}
           onLongPress={this._onPhotoLongPress}
-          delayLongPress={this.props.delayLongPress}>
-          <Photo
-            ref={ref => this.photoRefs[rowID] = ref}
-            lazyLoad
-            useCircleProgress={useCircleProgress}
-            uri={media.photo}
-            displaySelectionButtons={displaySelectionButtons}
-            selected={media.selected}
-            onSelection={(isSelected) => {
-              onMediaSelection(rowID, isSelected);
-            }}
-          />
-        </TouchableWithoutFeedback>
+          delayLongPress={this.props.delayLongPress}
+        />
       </View>
     );
   }

--- a/lib/GridContainer.js
+++ b/lib/GridContainer.js
@@ -63,23 +63,23 @@ export default class GridContainer extends React.Component {
     const photoWidth = (screenWidth / itemPerRow) - (ITEM_MARGIN * 2);
 
     return (
-      <TouchableHighlight onPress={() => onPhotoTap(parseInt(rowID, 10))}>
-        <View style={styles.row}>
-          <Photo
-            width={photoWidth}
-            height={square ? photoWidth : 100}
-            resizeMode={'cover'}
-            thumbnail
-            progressImage={require('../Assets/hourglass.png')}
-            displaySelectionButtons={displaySelectionButtons}
-            uri={media.thumb || media.photo}
-            selected={media.selected}
-            onSelection={(isSelected) => {
-              onMediaSelection(rowID, isSelected);
-            }}
-          />
-        </View>
-      </TouchableHighlight>
+      <View style={styles.row}>
+        <Photo
+          width={photoWidth}
+          height={square ? photoWidth : 100}
+          resizeMode={'cover'}
+          thumbnail
+          progressImage={require('../Assets/hourglass.png')}
+          displaySelectionButtons={displaySelectionButtons}
+          uri={media.thumb || media.photo}
+          selected={media.selected}
+          enablePinchToZoom={false}
+          onPress={() => onPhotoTap(parseInt(rowID, 10))}
+          onSelection={(isSelected) => {
+            onMediaSelection(rowID, isSelected);
+          }}
+        />
+      </View>
     );
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,6 +113,11 @@ export default class PhotoBrowser extends React.Component {
      */
     onPhotoLongPress: PropTypes.func,
     delayPhotoLongPress: PropTypes.number,
+
+    /*
+     * Whether pinch to zoom is enabled or disabled
+     */
+    enablePinchToZoom: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -131,6 +136,7 @@ export default class PhotoBrowser extends React.Component {
     displayTopBar: true,
     onPhotoLongPress: () => {},
     delayPhotoLongPress: 1000,
+    enablePinchToZoom: true,
     gridOffset: 0,
   };
 
@@ -298,6 +304,7 @@ export default class PhotoBrowser extends React.Component {
           bottomBarComponent={this.props.bottomBarComponent}
           onPhotoLongPress={this.props.onPhotoLongPress}
           delayLongPress={this.props.delayPhotoLongPress}
+          enablePinchToZoom={this.props.enablePinchToZoom}
         />
       );
     }

--- a/lib/media/Photo.js
+++ b/lib/media/Photo.js
@@ -8,6 +8,8 @@ import {
   TouchableWithoutFeedback,
   ActivityIndicator,
   Platform,
+  ScrollView,
+  Text,
 } from 'react-native';
 
 import * as Progress from 'react-native-progress';
@@ -75,6 +77,17 @@ export default class Photo extends Component {
      * iOS only
      */
     useCircleProgress: PropTypes.bool,
+
+    /*
+     * Whether or not the user can pinch to zoom in on a photo
+     */
+    enablePinchToZoom: PropTypes.bool,
+
+    onPress: PropTypes.func,
+
+    onLongPress: PropTypes.func,
+
+    delayLongPress: PropTypes.number,
   };
 
   static defaultProps = {
@@ -82,6 +95,7 @@ export default class Photo extends Component {
     thumbnail: false,
     lazyLoad: false,
     selected: false,
+    enablePinchToZoom: true,
   };
 
   constructor(props) {
@@ -91,6 +105,7 @@ export default class Photo extends Component {
     this._onError = this._onError.bind(this);
     this._onLoad = this._onLoad.bind(this);
     this._toggleSelection = this._toggleSelection.bind(this);
+    this._renderSelectionButton = this._renderSelectionButton.bind(this);
 
     const { lazyLoad, uri } = props;
 
@@ -217,6 +232,18 @@ export default class Photo extends Component {
     );
   }
 
+  _renderImage(props, style) {
+    return (
+      <TouchableWithoutFeedback
+        onPress={this.props.onPress}
+        onLongPress={this.props.onLongPress}
+        delayLongPress={this.props.delayLongPress}
+      >
+        <Image {...props} style={style} />
+      </TouchableWithoutFeedback>
+    );
+  }
+
   render() {
     const { resizeMode, width, height } = this.props;
     const screen = Dimensions.get('window');
@@ -237,18 +264,26 @@ export default class Photo extends Component {
       height: height || screen.height,
     };
 
+    const props = {
+      ...this.props,
+      source,
+      onProgress: this._onProgress,
+      onError: this._onError,
+      onLoad: this._onLoad,
+      resizeMode
+    };
+
     return (
       <View style={[styles.container, sizeStyle]}>
         {error ? this._renderErrorIcon() : this._renderProgressIndicator()}
-        <Image
-          {...this.props}
-          style={[styles.image, sizeStyle]}
-          source={source}
-          onProgress={this._onProgress}
-          onError={this._onError}
-          onLoad={this._onLoad}
-          resizeMode={resizeMode}
-        />
+        {
+          this.props.enablePinchToZoom ?
+            <ScrollView minimumZoomScale={1} maximumZoomScale={3} style={[styles.image, sizeStyle]} horizontal>
+              {this._renderImage(props, sizeStyle)}
+            </ScrollView>
+            :
+            this._renderImage(props, [sizeStyle, styles.image])
+        }
         {this._renderSelectionButton()}
       </View>
     );


### PR DESCRIPTION
This is done by wrapping the `<Image>` with a `<ScrollView>`.  Per [React Native's own docs](https://facebook.github.io/react-native/docs/using-a-scrollview.html), if a `<ScrollView>` contains only one element, it will enable the pinch to zoom capability.

Added a `enablePinchToZoom` prop which allows the user to enable or disable this functionality.

Had to move the onPress handler for showing/hiding the bottom and top bars down a level to be placed within the ScrollView to enable the correct behavior.