### PR TITLE
Add support for custom BottomBar buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The component has both iOS and Android support.
 |**`square`**|Boolean|Displays the thumbnails as squares(same width, height).|`false`|
 |**`gridOffset`**|Number|Offset the width of the grid from the screen width.|`0`|
 |**`customTitle`**|Function|Custom title in full screen mode.|`(index, rowCount) => { return '' }`|
+|**`customBottomBarButton`**|Component|Use a custom component in the bottom bar to the left of the Share button. The visibility of the Share button can still be controlled with `displayActionButton`.|`null`|
 
 ### Media Object
 

--- a/lib/FullScreenContainer.js
+++ b/lib/FullScreenContainer.js
@@ -61,7 +61,15 @@ export default class FullScreenContainer extends React.Component {
     useCircleProgress: PropTypes.bool,
     onActionButton: PropTypes.func,
     onPhotoLongPress: PropTypes.func,
-    delayLongPress: PropTypes.number
+    delayLongPress: PropTypes.number,
+
+    /**
+     * Use a custom button in the bottom bar to the left of the Share button,
+     * without having to recreate the entire bottom bar and pass it in with the
+     * `bottomBarComponent` prop. The visibility of the Share button can still
+     * be controlled with `displayActionButton`.
+     */
+    customBottomBarButton: PropTypes.element,
   };
 
   static defaultProps = {
@@ -296,6 +304,7 @@ export default class FullScreenContainer extends React.Component {
       displayActionButton,
       onGridButtonTap,
       enableGrid,
+      customBottomBarButton,
     } = this.props;
     const { controlsDisplayed, currentMedia } = this.state;
     const BottomBarComponent = this.props.bottomBarComponent || BottomBar;
@@ -322,11 +331,11 @@ export default class FullScreenContainer extends React.Component {
           onNext={this._onNextButtonTapped}
           onGrid={onGridButtonTap}
           onAction={this._onActionButtonTapped}
+          customButton={customBottomBarButton}
         />
       </View>
     );
   }
-
 }
 
 const styles = StyleSheet.create({

--- a/lib/bar/BottomBar.js
+++ b/lib/bar/BottomBar.js
@@ -114,13 +114,15 @@ export default class BottomBar extends React.Component {
   _renderActionSheet() {
     const { customButton, displayActionButton, onAction } = this.props;
 
-    let components = [];
+    const components = [];
 
-    if (customButton) components.push(customButton);
+    if (customButton) {
+      components.push(<View key={0}>{customButton}</View>);
+    }
 
     if (displayActionButton) {
       components.push(
-        <TouchableOpacity style={styles.button} onPress={onAction}>
+        <TouchableOpacity key={1} style={styles.button} onPress={onAction}>
           <Image source={require('../../Assets/share-button.png')} />
         </TouchableOpacity>
       );
@@ -128,9 +130,7 @@ export default class BottomBar extends React.Component {
     
     return (
       <View style={styles.rightButtonContainer}>
-        {components.map((component, index) => (
-          <View key={index}>{component}</View>
-        ))}
+        {components}
       </View>
     );
   }

--- a/lib/bar/BottomBar.js
+++ b/lib/bar/BottomBar.js
@@ -25,6 +25,7 @@ export default class BottomBar extends React.Component {
     onNext: PropTypes.func,
     onGrid: PropTypes.func,
     onAction: PropTypes.func,
+    customButton: PropTypes.element,
   };
 
   static defaultProps = {
@@ -99,7 +100,7 @@ export default class BottomBar extends React.Component {
 
     if (displayGridButton) {
       return (
-        <TouchableOpacity style={[styles.button, { flex: 0 }]} onPress={onGrid}>
+        <TouchableOpacity style={[styles.button, styles.gridButton]} onPress={onGrid}>
           <Image
             source={require('../../Assets/grid-button.png')}
             style={styles.buttonImage}
@@ -111,19 +112,27 @@ export default class BottomBar extends React.Component {
   }
 
   _renderActionSheet() {
-    const { displayActionButton, onAction } = this.props;
+    const { customButton, displayActionButton, onAction } = this.props;
+
+    let components = [];
+
+    if (customButton) components.push(customButton);
 
     if (displayActionButton) {
-      return (
-        <TouchableOpacity style={[styles.button, { flex: 0 }]} onPress={onAction}>
-          <Image
-            source={require('../../Assets/share-button.png')}
-            style={styles.buttonImage}
-          />
+      components.push(
+        <TouchableOpacity style={styles.button} onPress={onAction}>
+          <Image source={require('../../Assets/share-button.png')} />
         </TouchableOpacity>
       );
     }
-    return null;
+    
+    return (
+      <View style={styles.rightButtonContainer}>
+        {components.map((component, index) => (
+          <View key={index}>{component}</View>
+        ))}
+      </View>
+    );
   }
 
   render() {
@@ -176,11 +185,16 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 16,
   },
+  rightButtonContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
   button: {
     alignItems: 'center',
     width: BUTTON_WIDTH,
   },
-  buttonImage: {
-    marginTop: 8,
-  },
+  gridButton: {
+    flex: 0,
+    paddingTop: 8,
+  }
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,14 @@ export default class PhotoBrowser extends React.Component {
      */
     onPhotoLongPress: PropTypes.func,
     delayPhotoLongPress: PropTypes.number,
+
+    /**
+     * Use a custom button in the bottom bar to the left of the Share button,
+     * without having to recreate the entire bottom bar and pass it in with the
+     * `bottomBarComponent` prop. The visibility of the Share button can still
+     * be controlled with `displayActionButton`.
+     */
+    customBottomBarButton: PropTypes.element,
   };
 
   static defaultProps = {
@@ -261,6 +269,7 @@ export default class PhotoBrowser extends React.Component {
           bottomBarComponent={this.props.bottomBarComponent}
           onPhotoLongPress={this.props.onPhotoLongPress}
           delayLongPress={this.props.delayPhotoLongPress}
+          customBottomBarButton={this.props.customBottomBarButton}
         />
       );
     }


### PR DESCRIPTION
This PR adds support for passing in a custom component to the `customBottomBarButton` prop, placing it to the left of the Share button. The visibility of the Share button can still be controlled using `displayActionButton`. Even though you can override the bottom bar entirely using the `bottomBarComponent` prop, adding just a button to the existing bar is more convenient.

Here's a sample of what it looks like (the custom component is circled in the screenshot):
```js
<PhotoBrowser
    ...
    customBottomBarButton={
        <View style={{ backgroundColor: "blue" }}>
            <Text style={{ color: "white" }}>Test</Text>
        </View>
    }
/>
```
![Simulator Screen Shot - iPhone 8 - 2019-10-25 at 20 30 42](https://user-images.githubusercontent.com/12683684/67611529-199eae80-f768-11e9-9797-bef79210907a.png)

Let me know what you think — thanks for providing this project!