### PR TITLE
Add backTitle & backIcon to PhotoBrowser's properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ The component has both iOS and Android support.
 |**`onSelectionChanged`**|Function|Called when a media item is selected or unselected.|`(media, index, isSelected) => {}`|
 |**`onActionButton`**|Function|Called when action button is pressed for a photo. Your application should handle sharing process, please see [Sharing](#sharing) section for more information. If you don't provide this method, action button tap event will simply be ignored.|`(media, index) => {}`|
 |**`onBack`**|Function|Called when back button is tapped.|`() => {}`|
-|**`backIcon`**|ReactNode &#124; ImageSourcePropType|Back button icon|`require('../Assets/angle-left.png')`|
+|**`backIcon`**|ImageSourcePropType|Back button icon|`require('../Assets/angle-left.png')`|
+|**`backElement`**|ReactNode|Back button icon|`<MyBackIcon />`|
 |**`backTitle`**|String &#124; null|Back button title|`Back`|
 |**`itemPerRow`**|Number|Sets images amount in grid row.|`3`|
 |**`onPhotoLongPress`**|Function|Called when a long press trigged on a photo.|`() => {}`|

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The component has both iOS and Android support.
 |**`onSelectionChanged`**|Function|Called when a media item is selected or unselected.|`(media, index, isSelected) => {}`|
 |**`onActionButton`**|Function|Called when action button is pressed for a photo. Your application should handle sharing process, please see [Sharing](#sharing) section for more information. If you don't provide this method, action button tap event will simply be ignored.|`(media, index) => {}`|
 |**`onBack`**|Function|Called when back button is tapped.|`() => {}`|
+|**`backIcon`**|ReactNode &#124; ImageSourcePropType|Back button icon|`require('../Assets/angle-left.png')`|
+|**`backTitle`**|String &#124; null|Back button title|`Back`|
 |**`itemPerRow`**|Number|Sets images amount in grid row.|`3`|
 |**`onPhotoLongPress`**|Function|Called when a long press trigged on a photo.|`() => {}`|
 |**`delayPhotoLongPress`**|Number|The long press delay in `ms`.|`1000`|

--- a/lib/bar/TopBar.js
+++ b/lib/bar/TopBar.js
@@ -20,6 +20,7 @@ export default class TopBar extends React.Component {
     height: PropTypes.number,
     backTitle: PropTypes.string,
     backIcon: PropTypes.any,
+    backElement: PropTypes.element,
     onBack: PropTypes.func,
   };
 
@@ -31,14 +32,15 @@ export default class TopBar extends React.Component {
   };
 
   renderBackButton() {
-    const { onBack, backIcon } = this.props;
+    const { onBack, backIcon, backElement } = this.props;
+    const useBackElement = !!backElement && React.isValidElement(backElement);
 
     // do not display back button if there isn't a press handler
     if (onBack) {
       return (
         <TouchableOpacity style={styles.backContainer} onPress={onBack}>
-          {backIcon && React.isValidElement(backIcon) && backIcon}
-          {backIcon && !React.isValidElement(backIcon) && <Image source={backIcon} />}
+          {useBackElement && backElement}
+          {!useBackElement && !!backIcon && <Image source={backIcon} />}
           {Platform.OS === 'ios' && this.props.backTitle && this.props.backTitle.length > 0 && (
             <Text style={[styles.text, styles.backText]}>
               {this.props.backTitle}

--- a/lib/bar/TopBar.js
+++ b/lib/bar/TopBar.js
@@ -19,29 +19,31 @@ export default class TopBar extends React.Component {
     title: PropTypes.string,
     height: PropTypes.number,
     backTitle: PropTypes.string,
-    backImage: PropTypes.any,
+    backIcon: PropTypes.any,
     onBack: PropTypes.func,
   };
 
   static defaultProps = {
     displayed: false,
     title: '',
-    backTitle: 'Back',
-    backImage: require('../../Assets/angle-left.png'),
+    backTitle: '',
+    backIcon: null,
   };
 
   renderBackButton() {
-    const { onBack, backImage } = this.props;
+    const { onBack, backIcon } = this.props;
 
     // do not display back button if there isn't a press handler
     if (onBack) {
       return (
         <TouchableOpacity style={styles.backContainer} onPress={onBack}>
-          <Image source={backImage} />
-          {Platform.OS === 'ios' &&
+          {backIcon && React.isValidElement(backIcon) && backIcon}
+          {backIcon && !React.isValidElement(backIcon) && <Image source={backIcon} />}
+          {Platform.OS === 'ios' && this.props.backTitle && this.props.backTitle.length > 0 && (
             <Text style={[styles.text, styles.backText]}>
               {this.props.backTitle}
-            </Text>}
+            </Text>
+          )}
         </TouchableOpacity>
       );
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,10 +98,20 @@ export default class PhotoBrowser extends React.Component {
     onBack: PropTypes.func,
 
     /*
+     * Custom back title.
+     */
+    backTitle: PropTypes.string,
+
+    /*
+     * Custom back icon. Could be an ImageSourcePropType or a react node.
+     */
+    backIcon: PropTypes.any,
+
+    /*
      * Sets images amount in grid row, default - 3 (defined in GridContainer)
      */
     itemPerRow: PropTypes.number,
-  
+
     /*
      * Display top bar
      */
@@ -139,6 +149,8 @@ export default class PhotoBrowser extends React.Component {
     onPhotoLongPress: () => {},
     delayPhotoLongPress: 1000,
     gridOffset: 0,
+    backTitle: 'Back',
+    backIcon: require('../Assets/angle-left.png'),
   };
 
   constructor(props, context) {
@@ -210,7 +222,9 @@ export default class PhotoBrowser extends React.Component {
       square,
       gridOffset,
       customTitle,
-      onSelectionChanged
+      onSelectionChanged,
+      backTitle,
+      backIcon
     } = this.props;
     const {
       isFullScreen,
@@ -286,6 +300,8 @@ export default class PhotoBrowser extends React.Component {
         <TopBarComponent
           height={TOOLBAR_HEIGHT}
           displayed={displayTopBar}
+          backTitle={backTitle}
+          backIcon={backIcon}
           title={mediaList.length && isFullScreen ? title : `${mediaList.length} photos`}
           onBack={onBack}
         />

--- a/lib/index.js
+++ b/lib/index.js
@@ -103,9 +103,14 @@ export default class PhotoBrowser extends React.Component {
     backTitle: PropTypes.string,
 
     /*
-     * Custom back icon. Could be an ImageSourcePropType or a react node.
+     * Custom back icon. Must be an ImageSourcePropType.
      */
     backIcon: PropTypes.any,
+
+    /*
+     * Custom back element. Must be a react node.
+     */
+    backElement: PropTypes.any,
 
     /*
      * Sets images amount in grid row, default - 3 (defined in GridContainer)
@@ -224,7 +229,8 @@ export default class PhotoBrowser extends React.Component {
       customTitle,
       onSelectionChanged,
       backTitle,
-      backIcon
+      backIcon,
+      backElement
     } = this.props;
     const {
       isFullScreen,
@@ -302,6 +308,7 @@ export default class PhotoBrowser extends React.Component {
           displayed={displayTopBar}
           backTitle={backTitle}
           backIcon={backIcon}
+          backElement={backElement}
           title={mediaList.length && isFullScreen ? title : `${mediaList.length} photos`}
           onBack={onBack}
         />


### PR DESCRIPTION
This pull request allows you to configure the label of the back button and the icon on back button. If nothing is entered, the default values are kept. **Breaking Change**: the "backImage" property in the TopBar component has been renamed to "backIcon".